### PR TITLE
properly detect mmcblk install targets

### DIFF
--- a/scripts/install.sh.d/02-partitioning.sh
+++ b/scripts/install.sh.d/02-partitioning.sh
@@ -10,6 +10,8 @@ if [[ $OSI_DEVICE_IS_PARTITION -ne 0 ]]; then
 	declare -r partition_path="${OSI_DEVICE_PATH}"
 elif [[ $OSI_DEVICE_PATH == *"nvme"*"n"* ]]; then
 	declare -r partition_path="${OSI_DEVICE_PATH}p"
+elif [[ $OSI_DEVICE_PATH == *"mmcblk"* ]]; then
+	declare -r partition_path="${OSI_DEVICE_PATH}p"
 else
 	declare -r partition_path="${OSI_DEVICE_PATH}"
 fi


### PR DESCRIPTION
previously the installer would fail if the install target was "/dev/mmcblkX" due to trying to use partition names "/dev/mmcblkX1" instead of "/dev/mmcblkXp1"